### PR TITLE
fix scaling being lost

### DIFF
--- a/src/d2dx/D2DXContext.cpp
+++ b/src/d2dx/D2DXContext.cpp
@@ -256,7 +256,7 @@ void D2DXContext::OnSstWinOpen(
 			windowSize.width = width;
 			windowSize.height = height;
 		}
-		_renderContext->SetSizes(gameSize, windowSize);
+		_renderContext->SetSizes(gameSize, windowSize * _options.defaultZoomLevel);
 	}
 
 	_batchCount = 0;


### PR DESCRIPTION
This resolves scaling not working for me on a 1.10 version of Eastern Sun.