### PR TITLE
Add option "no title change"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Windowed/fullscreen mode can be switched at any time by pressing ALT-Enter.
   -dxnologo
   ``` 
   
+  Disable custom D2DX window title
+  ```
+  -dxnotitlechange
+  ```
+  
   Disable widescreen mode
   ```
   -dxnowide 

--- a/src/d2dx/D2DXContext.cpp
+++ b/src/d2dx/D2DXContext.cpp
@@ -60,6 +60,7 @@ static Options GetCommandLineOptions()
 	options.noVSync = CheckOption(commandLine, cfgFile, "-dxnovsync");
 	options.noAA = CheckOption(commandLine, cfgFile, "-dxnoaa");
 	options.noCompatModeFix = CheckOption(commandLine, cfgFile, "-dxnocompatmodefix");
+	options.noTitleChange = CheckOption(commandLine, cfgFile, "-dxnotitlechange");
 
 	bool dxscale2 = CheckOption(commandLine, cfgFile, "-dxscale2");
 	bool dxscale3 = CheckOption(commandLine, cfgFile, "-dxscale3");

--- a/src/d2dx/RenderContext.cpp
+++ b/src/d2dx/RenderContext.cpp
@@ -840,12 +840,14 @@ void RenderContext::AdjustWindowPlacement(
 
 	ClipCursor();
 
-	char newWindowText[256];
-	sprintf_s(newWindowText, "Diablo II DX [%ix%i, scale %i%%]",
-		_gameSize.width,
-		_gameSize.height,
-		(int)(((float)_renderRect.size.height / _gameSize.height) * 100.0f));
-	SetWindowTextA(hWnd, newWindowText);
+	if (!_d2dxContext->GetOptions().noTitleChange) {
+		char newWindowText[256];
+		sprintf_s(newWindowText, "Diablo II DX [%ix%i, scale %i%%]",
+			_gameSize.width,
+			_gameSize.height,
+			(int)(((float)_renderRect.size.height / _gameSize.height) * 100.0f));
+		SetWindowTextA(hWnd, newWindowText);
+	}
 
 	D2DX_LOG("Sizes: desktop %ix%i, window %ix%i, game %ix%i, render %ix%i", 
 		_desktopSize.width,

--- a/src/d2dx/Types.h
+++ b/src/d2dx/Types.h
@@ -53,6 +53,7 @@ namespace d2dx
 		bool noResMod = false;
 		bool noAA = false;
 		bool noCompatModeFix = false;
+		bool noTitleChange = false;
 		bool debugDumpTextures = false;
 		bool testMoP = false;
 	};


### PR DESCRIPTION
Adds command-line option -dxnotitlechange, disabling window title override by D2DX.

Preserving the default title is useful when users have their own custom titles set, making muling easier.