### PR TITLE
Add option "no window move"

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Windowed/fullscreen mode can be switched at any time by pressing ALT-Enter.
   -dxnoaa
   ```
   
+  In window mode, keeps window in upper-left corner
+  ```
+  -dxnowindowmove
+  ```
+  
   In windowed mode, scale the size by 2 or 3:
   ```
   -dxscale2

--- a/src/d2dx/D2DXContext.cpp
+++ b/src/d2dx/D2DXContext.cpp
@@ -60,6 +60,7 @@ static Options GetCommandLineOptions()
 	options.noVSync = CheckOption(commandLine, cfgFile, "-dxnovsync");
 	options.noAA = CheckOption(commandLine, cfgFile, "-dxnoaa");
 	options.noCompatModeFix = CheckOption(commandLine, cfgFile, "-dxnocompatmodefix");
+	options.noWindowMove = CheckOption(commandLine, cfgFile, "-dxnowindowmove");
 
 	bool dxscale2 = CheckOption(commandLine, cfgFile, "-dxscale2");
 	bool dxscale3 = CheckOption(commandLine, cfgFile, "-dxscale3");

--- a/src/d2dx/RenderContext.cpp
+++ b/src/d2dx/RenderContext.cpp
@@ -817,10 +817,15 @@ void RenderContext::AdjustWindowPlacement(
 		AdjustWindowRect(&windowRect, windowStyle, FALSE);
 		const int32_t newWindowWidth = windowRect.right - windowRect.left;
 		const int32_t newWindowHeight = windowRect.bottom - windowRect.top;
-		const int32_t newWindowCenterX = centerOnCurrentPosition ? oldWindowCenterX : desktopCenterX;
-		const int32_t newWindowCenterY = centerOnCurrentPosition ? oldWindowCenterY : desktopCenterY;
-		const int32_t newWindowX = newWindowCenterX - newWindowWidth / 2;
-		const int32_t newWindowY = newWindowCenterY - newWindowHeight / 2;
+		int32_t newWindowX = 0;
+		int32_t newWindowY = 0;
+
+		if (!_d2dxContext->GetOptions().noWindowMove) {
+			const int32_t newWindowCenterX = centerOnCurrentPosition ? oldWindowCenterX : desktopCenterX;
+			const int32_t newWindowCenterY = centerOnCurrentPosition ? oldWindowCenterY : desktopCenterY;
+			newWindowX = newWindowCenterX - newWindowWidth / 2;
+			newWindowY = newWindowCenterY - newWindowHeight / 2;
+		}
 
 		SetWindowLongPtr(hWnd, GWL_STYLE, windowStyle);
 		SetWindowPos_Real(hWnd, HWND_TOP, newWindowX, newWindowY, newWindowWidth, newWindowHeight, SWP_SHOWWINDOW | SWP_NOSENDCHANGING | SWP_FRAMECHANGED);

--- a/src/d2dx/Types.h
+++ b/src/d2dx/Types.h
@@ -53,6 +53,7 @@ namespace d2dx
 		bool noResMod = false;
 		bool noAA = false;
 		bool noCompatModeFix = false;
+		bool noWindowMove = false;
 		bool debugDumpTextures = false;
 		bool testMoP = false;
 	};


### PR DESCRIPTION
Adds command-line option -dxnowindowmove, preventing D2DX from centering the window, keeping it in the upper-left corner of the screen.

It would be even nicer to be able to move the window using the title bar, but I played around with the window flags and couldn't get it to work.