### PR TITLE
Support floating-point window scale values

### DIFF
--- a/d2dx-defaults.cfg
+++ b/d2dx-defaults.cfg
@@ -6,7 +6,7 @@
 #
 
 [window]
-scale=1			# range 1.0-3.0, an rational scale factor for the window
+scale=1			# range 1.0-3.0, a rational scale factor for the window
 position=[-1,-1]	# if [-1,-1] the window will be centered, otherwise placed at the explicit position given here
 frameless=false         # if true, the window frame (caption bar etc) will be removed
 

--- a/d2dx-defaults.cfg
+++ b/d2dx-defaults.cfg
@@ -6,7 +6,7 @@
 #
 
 [window]
-scale=1			# range 1-3, an integer scale factor for the window
+scale=1			# range 1.0-3.0, an rational scale factor for the window
 position=[-1,-1]	# if [-1,-1] the window will be centered, otherwise placed at the explicit position given here
 frameless=false         # if true, the window frame (caption bar etc) will be removed
 

--- a/src/d2dx/Options.cpp
+++ b/src/d2dx/Options.cpp
@@ -110,10 +110,10 @@ void Options::ApplyCfg(
 
 	if (window)
 	{
-		auto windowScale = toml_int_in(window, "scale");
+		auto windowScale = toml_double_in(window, "scale");
 		if (windowScale.ok)
 		{
-			SetWindowScale((int32_t)windowScale.u.i);
+			SetWindowScale(windowScale.u.d);
 		}
 
 		auto windowPosition = toml_array_in(window, "position");
@@ -164,8 +164,8 @@ void Options::ApplyCommandLine(
 	if (strstr(cmdLine, "-dxnotitlechange")) SetFlag(OptionsFlag::NoTitleChange, true);
 	if (strstr(cmdLine, "-dxnomop")) SetFlag(OptionsFlag::NoMotionPrediction, true);
 
-	if (strstr(cmdLine, "-dxscale3")) SetWindowScale(3);
-	else if (strstr(cmdLine, "-dxscale2")) SetWindowScale(2);
+	if (strstr(cmdLine, "-dxscale3")) SetWindowScale(3.0);
+	else if (strstr(cmdLine, "-dxscale2")) SetWindowScale(2.0);
 
 	if (strstr(cmdLine, "-dxdbg_dump_textures")) SetFlag(OptionsFlag::DbgDumpTextures, true);
 }
@@ -190,15 +190,15 @@ void Options::SetFlag(
 	}
 }
 
-int32_t Options::GetWindowScale() const
+double Options::GetWindowScale() const
 {
 	return _windowScale;
 }
 
 void Options::SetWindowScale(
-	_In_ int32_t windowScale)
+	_In_ double windowScale)
 {
-	_windowScale = min(3, max(1, windowScale));
+	_windowScale = min(3.0, max(1.0, windowScale));
 }
 
 Offset Options::GetWindowPosition() const

--- a/src/d2dx/Options.h
+++ b/src/d2dx/Options.h
@@ -69,10 +69,10 @@ namespace d2dx
 			_In_ OptionsFlag flag,
 			_In_ bool value);
 
-		int32_t GetWindowScale() const;
+		double GetWindowScale() const;
 
 		void SetWindowScale(
-			_In_ int32_t zoomLevel);
+			_In_ double zoomLevel);
 
 		Offset GetWindowPosition() const;
 
@@ -88,7 +88,7 @@ namespace d2dx
 
 	private:
 		uint32_t _flags = 0;
-		int32_t _windowScale = 1;
+		double _windowScale = 1.0;
 		Offset _windowPosition{ -1, -1 };
 		Size _userSpecifiedGameSize{ -1, -1 };
 		FilteringOption _filtering{ FilteringOption::HighQuality };

--- a/src/d2dx/Types.h
+++ b/src/d2dx/Types.h
@@ -322,6 +322,11 @@ namespace d2dx
 		int32_t width = 0;
 		int32_t height = 0;
 
+		Size operator*(double value) noexcept
+		{
+			return { (int32_t)(width * value), (int32_t)(height * value) };
+		}
+
 		Size operator*(int32_t value) noexcept
 		{
 			return { width * value, height * value };


### PR DESCRIPTION
This PR adds support for floating-point window scale values.
The change is backward compatible and tested manually on my PC.

Example:
```ini
[window]
scale=1.25
```

![image](https://user-images.githubusercontent.com/5188088/131262147-c092e31c-f099-4f8a-9cf0-825df6e2adca.png)
