### PR TITLE
Use the full screen width when playing cutscenes

### DIFF
--- a/d2dx-defaults.cfg
+++ b/d2dx-defaults.cfg
@@ -30,3 +30,4 @@ noaa=false		 # if true, will not apply anti-aliasing to jagged edges
 nocompatmodefix=false	 # if true, will not block the use of "Windows XP compatibility mode"
 notitlechange=false	 # if true, will not change the window title text
 nomotionprediction=false # if true, will not run the game graphics at high fps
+nokeepaspectratio=false # if true, will not keep the aspect ratio when drawing to the screen

--- a/src/d2dx/D2DXContext.cpp
+++ b/src/d2dx/D2DXContext.cpp
@@ -323,9 +323,10 @@ void D2DXContext::CheckMajorGameState()
 {
 	const int32_t batchCount = (int32_t)_batchCount;
 
-	if (_majorGameState == MajorGameState::Unknown && batchCount == 0)
+	if ((_majorGameState == MajorGameState::Unknown || _majorGameState == MajorGameState::FmvIntro) && batchCount == 0)
 	{
 		_majorGameState = MajorGameState::FmvIntro;
+		return;
 	}
 
 	_majorGameState = MajorGameState::Menus;
@@ -1020,7 +1021,8 @@ void D2DXContext::OnLfbUnlock(
 	const uint32_t* lfbPtr,
 	uint32_t strideInBytes)
 {
-	_renderContext->WriteToScreen(lfbPtr, 640, 480);
+	bool forCinematic = !(_majorGameState == MajorGameState::Unknown || _majorGameState == MajorGameState::FmvIntro);
+	_renderContext->WriteToScreen(lfbPtr, 640, 480, forCinematic);
 }
 
 _Use_decl_annotations_

--- a/src/d2dx/D2DXContext.cpp
+++ b/src/d2dx/D2DXContext.cpp
@@ -222,7 +222,7 @@ void D2DXContext::OnSstWinOpen(
 			windowSize.width = width;
 			windowSize.height = height;
 		}
-		_renderContext->SetSizes(gameSize, windowSize * _options.GetWindowScale());
+		_renderContext->SetSizes(gameSize, windowSize * _options.GetWindowScale(), _renderContext->GetScreenMode());
 	}
 
 	_batchCount = 0;

--- a/src/d2dx/IRenderContext.h
+++ b/src/d2dx/IRenderContext.h
@@ -55,7 +55,8 @@ namespace d2dx
 		virtual void WriteToScreen(
 			_In_reads_(width * height) const uint32_t* pixels,
 			_In_ int32_t width,
-			_In_ int32_t height) = 0;
+			_In_ int32_t height,
+			_In_ bool forCinematic) = 0;
 
 		virtual void SetPalette(
 			_In_ int32_t paletteIndex,

--- a/src/d2dx/IRenderContext.h
+++ b/src/d2dx/IRenderContext.h
@@ -68,7 +68,8 @@ namespace d2dx
 
 		virtual void SetSizes(
 			_In_ Size gameSize,
-			_In_ Size windowSize) = 0;
+			_In_ Size windowSize,
+			_In_ ScreenMode screenMode) = 0;
 
 		virtual void GetCurrentMetrics(
 			_Out_opt_ Size* gameSize,

--- a/src/d2dx/Metrics.cpp
+++ b/src/d2dx/Metrics.cpp
@@ -184,8 +184,12 @@ _Use_decl_annotations_
 Rect d2dx::Metrics::GetRenderRect(
 	Size gameSize,
 	Size desktopSize,
-	bool wide) noexcept
+	bool keepAspect) noexcept
 {
+	if (!keepAspect) {
+		return Rect{ 0, 0, desktopSize.width, desktopSize.height };
+	}
+
 	int32_t scaleFactor = 1;
 
 	while (

--- a/src/d2dx/Options.cpp
+++ b/src/d2dx/Options.cpp
@@ -79,6 +79,7 @@ void Options::ApplyCfg(
 		READ_OPTOUTS_FLAG(OptionsFlag::NoCompatModeFix, "nocompatmodefix");
 		READ_OPTOUTS_FLAG(OptionsFlag::NoTitleChange, "notitlechange");
 		READ_OPTOUTS_FLAG(OptionsFlag::NoMotionPrediction, "nomotionprediction");
+		READ_OPTOUTS_FLAG(OptionsFlag::NoKeepAspectRatio, "nokeepaspectratio");
 
 #undef READ_OPTOUTS_FLAG
 	}
@@ -163,6 +164,7 @@ void Options::ApplyCommandLine(
 	if (strstr(cmdLine, "-dxnocompatmodefix")) SetFlag(OptionsFlag::NoCompatModeFix, true);
 	if (strstr(cmdLine, "-dxnotitlechange")) SetFlag(OptionsFlag::NoTitleChange, true);
 	if (strstr(cmdLine, "-dxnomop")) SetFlag(OptionsFlag::NoMotionPrediction, true);
+	if (strstr(cmdLine, "-dxnokeepaspectratio")) SetFlag(OptionsFlag::NoKeepAspectRatio, true);
 
 	if (strstr(cmdLine, "-dxscale3")) SetWindowScale(3);
 	else if (strstr(cmdLine, "-dxscale2")) SetWindowScale(2);

--- a/src/d2dx/Options.h
+++ b/src/d2dx/Options.h
@@ -34,6 +34,7 @@ namespace d2dx
 		NoTitleChange,
 		NoVSync,
 		NoMotionPrediction,
+		NoKeepAspectRatio,
 
 		DbgDumpTextures,
 

--- a/src/d2dx/RenderContext.cpp
+++ b/src/d2dx/RenderContext.cpp
@@ -75,7 +75,7 @@ RenderContext::RenderContext(
 	_renderRect = Metrics::GetRenderRect(
 		gameSize,
 		_screenMode == ScreenMode::FullscreenDefault ? _desktopSize : _windowSize,
-		!_d2dxContext->GetOptions().GetFlag(OptionsFlag::NoWide));
+		!_d2dxContext->GetOptions().GetFlag(OptionsFlag::NoKeepAspectRatio));
 
 #ifndef NDEBUG
 	ShowCursor_Real(TRUE);
@@ -874,7 +874,7 @@ void RenderContext::SetSizes(
 	_renderRect = Metrics::GetRenderRect(
 		_gameSize,
 		displaySize,
-		!_d2dxContext->GetOptions().GetFlag(OptionsFlag::NoWide));
+		!_d2dxContext->GetOptions().GetFlag(OptionsFlag::NoKeepAspectRatio));
 
 	bool centerOnCurrentPosition = _hasAdjustedWindowPlacement;
 	_hasAdjustedWindowPlacement = true;
@@ -917,7 +917,7 @@ void RenderContext::SetSizes(
 			_renderRect = Metrics::GetRenderRect(
 				_gameSize,
 				_windowSize,
-				!_d2dxContext->GetOptions().GetFlag(OptionsFlag::NoWide));
+				!_d2dxContext->GetOptions().GetFlag(OptionsFlag::NoKeepAspectRatio));
 
 			windowRect = { 0, 0, _windowSize.width, _windowSize.height };
 			AdjustWindowRect(&windowRect, windowStyle, FALSE);

--- a/src/d2dx/RenderContext.cpp
+++ b/src/d2dx/RenderContext.cpp
@@ -511,24 +511,39 @@ _Use_decl_annotations_
 void RenderContext::WriteToScreen(
 	const uint32_t* pixels,
 	int32_t width,
-	int32_t height)
+	int32_t height,
+	bool forCinematic)
 {
 	D3D11_MAPPED_SUBRESOURCE ms;
-	D2DX_CHECK_HR(_deviceContext->Map(_resources->GetVideoTexture(), 0, D3D11_MAP_WRITE_DISCARD, 0, &ms));
-	memcpy(ms.pData, pixels, width * height * 4);
-	_deviceContext->Unmap(_resources->GetVideoTexture(), 0);
-
 	SetBlendState(AlphaBlend::Opaque);
-
-	SetShaderState(
-		_resources->GetVertexShader(RenderContextVertexShader::Display),
-		_resources->GetPixelShader(RenderContextPixelShader::Video),
-		_resources->GetVideoSrv(),
-		nullptr);
-
 	uint32_t startVertexLocation = _vbWriteIndex;
-	uint32_t vertexCount = UpdateVerticesWithFullScreenTriangle(_gameSize, _resources->GetVideoTextureSize(), { 0,0,_gameSize.width, _gameSize.height });
-	UpdateViewport({ 0,0,_gameSize.width, _gameSize.height });
+	uint32_t vertexCount = 0;
+
+	if (forCinematic) {
+		SetSizes({ width, 292 }, _windowSize, _screenMode);
+		D2DX_CHECK_HR(_deviceContext->Map(_resources->GetCinematicTexture(), 0, D3D11_MAP_WRITE_DISCARD, 0, &ms));
+		memcpy(ms.pData, &pixels[width * 94], width * 292 * 4);
+		_deviceContext->Unmap(_resources->GetCinematicTexture(), 0);
+		SetShaderState(
+			_resources->GetVertexShader(RenderContextVertexShader::Display),
+			_resources->GetPixelShader(RenderContextPixelShader::Video),
+			_resources->GetCinematicSrv(),
+			nullptr);
+		vertexCount = UpdateVerticesWithFullScreenTriangle(_gameSize, _resources->GetCinematicTextureSize(), { 0,0,_gameSize.width, _gameSize.height });
+	}
+	else {
+		D2DX_CHECK_HR(_deviceContext->Map(_resources->GetVideoTexture(), 0, D3D11_MAP_WRITE_DISCARD, 0, &ms));
+		memcpy(ms.pData, pixels, width * height * 4);
+		_deviceContext->Unmap(_resources->GetVideoTexture(), 0);
+		SetShaderState(
+			_resources->GetVertexShader(RenderContextVertexShader::Display),
+			_resources->GetPixelShader(RenderContextPixelShader::Video),
+			_resources->GetVideoSrv(),
+			nullptr);
+		vertexCount = UpdateVerticesWithFullScreenTriangle(_gameSize, _resources->GetVideoTextureSize(), { 0,0,_gameSize.width, _gameSize.height });
+		UpdateViewport({ 0,0,_gameSize.width, _gameSize.height });
+	}
+
 	_deviceContext->Draw(vertexCount, startVertexLocation);
 
 	Present();

--- a/src/d2dx/RenderContext.h
+++ b/src/d2dx/RenderContext.h
@@ -99,7 +99,8 @@ namespace d2dx
 
 		virtual void SetSizes(
 			_In_ Size gameSize,
-			_In_ Size windowSize) override;
+			_In_ Size windowSize,
+			_In_ ScreenMode screenMode) override;
 
 		virtual void GetCurrentMetrics(
 			_Out_opt_ Size* gameSize,

--- a/src/d2dx/RenderContext.h
+++ b/src/d2dx/RenderContext.h
@@ -86,7 +86,8 @@ namespace d2dx
 		virtual void WriteToScreen(
 			_In_reads_(width* height) const uint32_t* pixels,
 			_In_ int32_t width,
-			_In_ int32_t height) override;
+			_In_ int32_t height,
+			_In_ bool forCinematic) override;
 
 		virtual void SetPalette(
 			_In_ int32_t paletteIndex,

--- a/src/d2dx/RenderContextResources.cpp
+++ b/src/d2dx/RenderContextResources.cpp
@@ -81,6 +81,22 @@ ITextureCache* RenderContextResources::GetTextureCache(
 	return _textureCaches[log2Longest].get();
 }
 
+void RenderContextResources::SetFramebufferSize(
+	Size framebufferSize,
+	ID3D11Device* device)
+{
+	_framebuffers[0].texture = nullptr;
+	_framebuffers[0].rtv= nullptr;
+	_framebuffers[0].srv= nullptr;
+	_framebuffers[1].texture = nullptr;
+	_framebuffers[1].rtv = nullptr;
+	_framebuffers[1].srv = nullptr;
+	_framebuffers[2].texture = nullptr;
+	_framebuffers[2].rtv = nullptr;
+	_framebuffers[2].srv = nullptr;
+	CreateFramebuffers(framebufferSize, device);
+}
+
 _Use_decl_annotations_
 void RenderContextResources::CreateShadersAndInputLayout(
 	ID3D11Device* device)

--- a/src/d2dx/RenderContextResources.cpp
+++ b/src/d2dx/RenderContextResources.cpp
@@ -270,12 +270,22 @@ void RenderContextResources::CreateVideoTextures(
 	};
 
 	_videoTextureSize = { 640, 480 };
+	_cinematicTextureSize = { 640, 292 };
 
 	D2DX_CHECK_HR(
 		device->CreateTexture2D(&desc, NULL, &_videoTexture));
 
 	D2DX_CHECK_HR(
 		device->CreateShaderResourceView(_videoTexture.Get(), NULL, &_videoTextureSrv));
+
+	desc.Height = 292;
+	
+	D2DX_CHECK_HR(
+		device->CreateTexture2D(&desc, NULL, &_cinematicTexture));
+
+	D2DX_CHECK_HR(
+		device->CreateShaderResourceView(_cinematicTexture.Get(), NULL, &_cinematicTextureSrv));
+
 }
 
 _Use_decl_annotations_

--- a/src/d2dx/RenderContextResources.h
+++ b/src/d2dx/RenderContextResources.h
@@ -122,6 +122,21 @@ namespace d2dx
 			return _videoTextureSrv.Get();
 		}
 
+		Size GetCinematicTextureSize() const
+		{
+			return _cinematicTextureSize;
+		}
+
+		ID3D11Texture2D* GetCinematicTexture() const
+		{
+			return _cinematicTexture.Get();
+		}
+
+		ID3D11ShaderResourceView* GetCinematicSrv() const
+		{
+			return _cinematicTextureSrv.Get();
+		}
+
 		ID3D11RasterizerState* GetRasterizerState(bool enableScissor) const
 		{
 			return enableScissor ? _rasterizerState.Get() : _rasterizerStateNoScissor.Get();
@@ -221,6 +236,10 @@ namespace d2dx
 		Size _videoTextureSize;
 		ComPtr<ID3D11Texture2D> _videoTexture;
 		ComPtr<ID3D11ShaderResourceView> _videoTextureSrv;
+
+		Size _cinematicTextureSize;
+		ComPtr<ID3D11Texture2D> _cinematicTexture;
+		ComPtr<ID3D11ShaderResourceView> _cinematicTextureSrv;
 
 		std::unique_ptr<ITextureCache> _textureCaches[7];
 

--- a/src/d2dx/RenderContextResources.h
+++ b/src/d2dx/RenderContextResources.h
@@ -79,6 +79,8 @@ namespace d2dx
 
 		void OnNewFrame();
 
+		void SetFramebufferSize(Size framebufferSize, ID3D11Device* device);
+
 		ID3D11InputLayout* GetInputLayout() const { return _inputLayout.Get(); }
 
 		ID3D11VertexShader* GetVertexShader(RenderContextVertexShader vertexShader) const


### PR DESCRIPTION
Splitting up #177 to make reviewing easier.

First commit removes the renderer's dependence on the widescreen flag. Not strictly needed, but it doesn't hurt anything.

fixes #99