### PR TITLE
Shrink the vertex buffer

### DIFF
--- a/src/d2dx/RenderContext.cpp
+++ b/src/d2dx/RenderContext.cpp
@@ -266,7 +266,7 @@ RenderContext::RenderContext(
 	renderTargetSize.width = max(1024, renderTargetSize.width);
 	renderTargetSize.height = max(768, renderTargetSize.height);
 
-	_vbCapacity = 4 * 1024 * 1024;
+	_vbCapacity = 1024 * 1024;
 
 	SetSizes(_gameSize, _windowSize);
 
@@ -400,7 +400,7 @@ void RenderContext::Present()
 	UpdateViewport(_renderRect);
 
 	RenderContextPixelShader pixelShader;
-	
+
 	switch (_d2dxContext->GetOptions().GetFiltering())
 	{
 	default:


### PR DESCRIPTION
Splitting up #177 for easier reviewing.

Really this should use multiple staging buffers, but just shrinking it works well enough.

hopefully fixes #125