### PR TITLE
Improve cursor locking behaviour

### DIFF
--- a/src/d2dx/RenderContext.cpp
+++ b/src/d2dx/RenderContext.cpp
@@ -400,7 +400,7 @@ void RenderContext::Present()
 	UpdateViewport(_renderRect);
 
 	RenderContextPixelShader pixelShader;
-	
+
 	switch (_d2dxContext->GetOptions().GetFiltering())
 	{
 	default:
@@ -1026,11 +1026,15 @@ void RenderContext::ClipCursor()
 		return;
 	}
 
-	RECT clipRect;
-	::GetClientRect(_hWnd, &clipRect);
+	RECT clipRect = {
+		_renderRect.offset.x,
+		_renderRect.offset.y,
+		_renderRect.offset.x + _renderRect.size.width,
+		_renderRect.offset.y + _renderRect.size.height
+	};
 	::ClientToScreen(_hWnd, (LPPOINT)&clipRect.left);
-	::ClientToScreen(_hWnd, (LPPOINT)&clipRect.right);
-	::ClipCursor(&clipRect);
+    ::ClientToScreen(_hWnd, (LPPOINT)&clipRect.right);
+    ::ClipCursor(&clipRect);
 }
 
 void RenderContext::UnclipCursor()

--- a/src/d2dx/RenderContext.h
+++ b/src/d2dx/RenderContext.h
@@ -113,7 +113,15 @@ namespace d2dx
 
 		virtual ScreenMode GetScreenMode() const override;
 
-		void ClipCursor();
+		void SetActiveWindow(bool active) {
+			if (!active)
+			{
+				UnclipCursor();
+			}
+			_isActiveWindow = active;
+		}
+
+		void ClipCursor(bool resizing);
 		void UnclipCursor();
 
 	private:
@@ -210,6 +218,8 @@ namespace d2dx
 		EventHandle _frameLatencyWaitableObject;
 		int64_t _timeStart;
 		bool _hasAdjustedWindowPlacement = false;
+		bool _isActiveWindow = false;
+		bool _isCursorClipped = false;
 
 		double _prevTime;
 		double _frameTimeMs;


### PR DESCRIPTION
fixes #159

First commit fixes the clipping region to the render region. Second commit keeps the game from stealing the mouse cursor's position until the mouse actually interacts with the game.